### PR TITLE
【個人開発5】ユーザー新規登録実装

### DIFF
--- a/src/main/java/com/spring/springbootapplication/controller/HomeController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/HomeController.java
@@ -1,4 +1,4 @@
-package com.spring.springbootapplication.controller;
+//package com.spring.springbootapplication.controller;
 
 //import org.springframework.web.bind.annotation.GetMapping;
 //import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/com/spring/springbootapplication/controller/HomeController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/HomeController.java
@@ -1,4 +1,4 @@
-//package com.spring.springbootapplication.controller;
+package com.spring.springbootapplication.controller;
 
 //import org.springframework.web.bind.annotation.GetMapping;
 //import org.springframework.web.bind.annotation.RestController;

--- a/src/main/resources/static/css/common.css
+++ b/src/main/resources/static/css/common.css
@@ -21,6 +21,7 @@ label {
 .wrapper{
     display: flex;
     flex-direction: column;
+    min-height: 100vh;
 }
 
 
@@ -69,7 +70,8 @@ label {
 .main-content{
     display: flex;
     justify-content: center;
-    margin-bottom: 319px;
+    margin: 0 auto;
+    flex: 1;
 }
 
 .form-container{

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -13,11 +13,12 @@
 
         <div class="main-content">
             <h1 class="main-title">登録が完了しました！</h1>
-            </div>
-        </div>
+        </div> <!-- ←ここの div 閉じタグは1つでOK -->
 
         <footer>
             <div class="footer">portfolio site</div>
         </footer>
+    </div> <!-- ← wrapper の閉じタグは最後に移動 -->
+
 </body>
 </html>

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -51,8 +51,4 @@
             </footer>
         </div>
     </body>
-
-
-
-
 </html>


### PR DESCRIPTION
# ユーザー新規登録機能の実装  
バリデーション付きフォーム・DB保存・登録後TOP遷移

---

### チケット
[PRUM_ACADEMY-5198](https://prum.backlog.com/view/PRUM_ACADEMY-5198) 【個人開発5】ユーザー新規登録実装

---

### 概要
ユーザーの新規登録機能を実装
氏名、メールアドレス、パスワードを入力して登録できる画面と処理を作成

---

### 内容

- 新規登録画面の追加
- `UserForm` クラスにバリデーションアノテーションを追加（氏名・メール・パスワード）
- ` RegisterController` に GET/POST の登録処理を実装
- バリデーションエラー時のエラーメッセージ表示対応
- 登録後は TOP 画面へリダイレクト
- 仮の TOP ページを追加

---

### 動作確認

- 入力エラー時、該当エラーメッセージが表示されることを確認
- 登録後、TOPページへ遷移することを確認

---

### 備考  
Slackにて動画を添付しました。
ご確認よろしくお願いいたします。
