### PR TITLE
ログイン画面追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
+	// 'org.springframework.boot:spring-boot-starter-security'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/com/spring/springbootapplication/controller/LoginController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/LoginController.java
@@ -1,0 +1,57 @@
+package com.spring.springbootapplication.controller;
+
+import com.spring.springbootapplication.dto.UserForm;
+import com.spring.springbootapplication.entity.User;
+import com.spring.springbootapplication.service.UserService;
+
+import jakarta.servlet.http.HttpSession;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+public class LoginController {
+
+    private final UserService userService;
+
+    public LoginController(UserService userService) {
+        this.userService = userService;
+    }
+
+    // ログインフォーム表示
+    @GetMapping("/login")
+    public String showLoginForm(
+            @ModelAttribute("userForm") UserForm userForm,
+            @ModelAttribute("errorMessage") String errorMessage,
+            Model model
+    ) {
+        if (!model.containsAttribute("userForm")) {
+            model.addAttribute("userForm", new UserForm());
+        }
+
+        model.addAttribute("loginError", errorMessage);
+        return "login";  // templates/login.html
+    }
+
+    // ログイン処理
+    @PostMapping("/login")
+    public String login(
+            @ModelAttribute("userForm") UserForm form,
+            RedirectAttributes redirectAttributes,
+            HttpSession session
+    ) {
+        User user = userService.login(form.getEmail(), form.getPassword());
+
+        if (user != null) {
+            session.setAttribute("loginUser", user);  // セッションに保存
+            return "redirect:/top";                   // トップページに遷移
+        } else {
+            // エラー情報をFlash Attributeに入れてリダイレクト
+            redirectAttributes.addFlashAttribute("errorMessage", "メールアドレス、もしくはパスワードが間違っています");
+            redirectAttributes.addFlashAttribute("userForm", form); // 入力情報を戻す
+            return "redirect:/login";
+        }
+    }
+}

--- a/src/main/java/com/spring/springbootapplication/controller/LogoutController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/LogoutController.java
@@ -1,0 +1,17 @@
+package com.spring.springbootapplication.controller;
+
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+public class LogoutController {
+
+    // POSTでログアウト処理
+    @PostMapping("/logout")
+    public String logout(HttpSession session) {
+        session.invalidate();  // セッションを破棄してログアウト
+        return "redirect:/login";  // ログイン画面へリダイレクト
+    }
+}

--- a/src/main/java/com/spring/springbootapplication/controller/RegisterController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/RegisterController.java
@@ -1,29 +1,70 @@
 package com.spring.springbootapplication.controller;
 
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.validation.BindingResult;
-import jakarta.validation.Valid;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+
 import com.spring.springbootapplication.dto.UserForm;
 import com.spring.springbootapplication.entity.User;
+import com.spring.springbootapplication.service.UserService;
 
 @Controller
 public class RegisterController {
-    @GetMapping("/register")
-    public String showRegisterForm(Model model) {
-        model.addAttribute("userForm", new UserForm());
-        return "register"; // templates/register.html を返す
+
+    private final UserService userService;
+
+    public RegisterController(UserService userService) {
+        this.userService = userService;
     }
 
-    @PostMapping("/register")
-public String registerUser(@Valid @ModelAttribute("userForm") UserForm userForm, BindingResult result, Model model) {
-    if (result.hasErrors()) {
-        return "register";
+    // 登録フォーム表示（GET）
+    @GetMapping("/register")
+    public String showRegisterForm(Model model) {
+        if (!model.containsAttribute("userForm")) {
+            model.addAttribute("userForm", new UserForm());
+        }
+        return "register"; // templates/register.html
     }
-    // 保存処理など
-    return "login"; // 登録成功ページに遷移
+
+    // 登録処理（POST）
+    @PostMapping("/register")
+public String registerUser(
+        @Valid @ModelAttribute("userForm") UserForm userForm,
+        BindingResult result,
+        RedirectAttributes redirectAttributes,
+        HttpSession session
+) {
+    // バリデーションエラー時はフォームに戻す
+    if (result.hasErrors()) {
+        redirectAttributes.addFlashAttribute("org.springframework.validation.BindingResult.userForm", result);
+        redirectAttributes.addFlashAttribute("userForm", userForm);
+        return "redirect:/register";
+    }
+
+    // 追加：メールアドレスの重複チェック
+    if (userService.existsByEmail(userForm.getEmail())) {
+        result.rejectValue("email", "error.userForm", "このメールアドレスは既に使われています");
+        redirectAttributes.addFlashAttribute("org.springframework.validation.BindingResult.userForm", result);
+        redirectAttributes.addFlashAttribute("userForm", userForm);
+        return "redirect:/register";
+    }
+
+    // ユーザーをエンティティにセットし保存
+    User user = new User();
+    user.setName(userForm.getName());
+    user.setEmail(userForm.getEmail());
+    user.setPassword(userForm.getPassword());
+    userService.save(user);
+
+    // 登録後、ログイン状態にしてトップ画面へ遷移
+    session.setAttribute("loginUser", user);
+
+    return "redirect:/top";
 }
+
 }

--- a/src/main/java/com/spring/springbootapplication/controller/TopController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/TopController.java
@@ -1,0 +1,13 @@
+package com.spring.springbootapplication.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class TopController {
+
+    @GetMapping("/top")
+    public String showTopPage() {
+        return "top";  // templates/top.html を返す
+    }
+}

--- a/src/main/java/com/spring/springbootapplication/repository/UserRepository.java
+++ b/src/main/java/com/spring/springbootapplication/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.spring.springbootapplication.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.spring.springbootapplication.entity.User;
+import java.util.Optional;
+
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    //ser findByEmailAndPassword(String email, String password);
+    boolean existsByEmail(String email);
+
+}

--- a/src/main/java/com/spring/springbootapplication/service/UserService.java
+++ b/src/main/java/com/spring/springbootapplication/service/UserService.java
@@ -1,0 +1,44 @@
+package com.spring.springbootapplication.service;
+
+import org.springframework.stereotype.Service;
+
+import com.spring.springbootapplication.entity.User;
+import com.spring.springbootapplication.repository.UserRepository;
+import java.util.Optional;
+
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    // コンストラクタ（SpringがDIしてくれる）
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    //public User login(String email, String password) {
+    //    return userRepository.findByEmailAndPassword(email, password);
+
+    public User login(String email, String password) {
+    Optional<User> optionalUser = userRepository.findByEmail(email);
+    if (optionalUser.isPresent()) {
+        User user = optionalUser.get();
+        if (user.getPassword().equals(password)) {
+            return user;
+        }
+    }
+    return null;
+    }
+
+    // ここからsaveメソッド
+    public void save(User user) {
+        userRepository.save(user);
+    }
+
+    public boolean existsByEmail(String email) {
+    return userRepository.existsByEmail(email);
+}
+
+
+} 

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -4,7 +4,7 @@ spring.datasource.username=miyabi
 spring.datasource.password=password
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-# Flywayの設定
+# Flywayの設定 
 spring.flyway.enabled=false
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/static/css/common.css
+++ b/src/main/resources/static/css/common.css
@@ -51,6 +51,7 @@ label {
     width: 152px;
     height: 53px;
     font-size: 18px;
+    border: none;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -78,13 +79,11 @@ label {
     flex: 1;
 }
 
-
 .form-container {
     width: 480px;
     margin: 0 auto;
     margin-top: 80px;
 }
-
 
 
 .form-container{
@@ -149,7 +148,7 @@ label {
 }
 
 /* 無効化 */
-.submit-btn:link,
+.submit-btn:link,   
 .submit-btn:visited {
     text-decoration: none;  
     color: #FFFFFF;  

--- a/src/main/resources/static/css/login.css
+++ b/src/main/resources/static/css/login.css
@@ -1,0 +1,26 @@
+/* ヘッダー */
+.header {
+    max-width: 100%;
+    height: 120px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: #FFFFFF;
+    background-color: #1B5678;
+}
+
+/* 送信ボタン */
+.submit-btn{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.button-wrapper {
+  margin-bottom: clamp(16px, 5vh, 48px); /* 最小16px、画面高5%、最大48px */
+}
+
+.error-message{
+  margin-top: 5px;
+  color: red;
+}

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -2,23 +2,45 @@
 <html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <title>登録完了</title>
-    <link rel="stylesheet" href="/css/common.css">
+    <title>ログインページ</title>
+        <link rel="stylesheet" href="/css/common.css">
+        <!--<link rel="stylesheet" href="common.css">-->
+        <link rel="stylesheet" href="/css/login.css">
+        <!--<link rel="stylesheet" href="login.css">-->
 </head>
 <body>
     <div class="wrapper">
-        <header class="header">
-            <div class="header-logo">My Portfolio</div>
-        </header>
 
-        <div class="main-content">
-            <h1 class="main-title">登録が完了しました！</h1>
-        </div> <!-- ←ここの div 閉じタグは1つでOK -->
-
+            <header class="header">
+                <div class="header-logo">My Portfolio</div>
+            </header>
+            <div class="main-content">
+                <form th:action="@{/login}" method="post" th:object="${userForm}">
+                    
+                    <h1 class="main-title">ログイン</h1>
+                    <div class="form-container">
+                        <div class="form-group">
+                            <label for="email">メールアドレス</label>
+                            <input type="text" class="form-control" th:field="*{email}" id="email" placeholder="メールアドレスを入力してください"/>
+                            <div class="text-danger" th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></div>
+                        </div>
+                        <div class="form-group">
+                            <label for="password">パスワード</label>
+                            <input type="password" class="form-control" th:field="*{password}" id="password" placeholder="パスワードを入力してください"/>
+                            <div class="text-danger" th:if="${#fields.hasErrors('password')}" 
+                                th:text="${#fields.errors('password')[0]}"></div>
+                                <div th:if="${loginError}" class="error-message" th:text="${loginError}"></div>
+                        </div>
+                        <div class="button-wrapper">
+                            <button type="submit" class="submit-btn">ログインする</button>
+                            <a href="/register" class="submit-btn">新規登録する</a> <!-- GET で登録画面へ遷移 -->
+                        </div>
+                    </div>
+                </form>
+            </div>
         <footer>
             <div class="footer">portfolio site</div>
         </footer>
-    </div> <!-- ← wrapper の閉じタグは最後に移動 -->
-
+    </div> 
 </body>
 </html>

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="description" content="ポートフォリオです">
-        <title>ログインページ</title>
+        <title>新規登録ページ</title>
         <link rel="stylesheet" href="/css/common.css">
         <!--<link rel="stylesheet" href="common.css">-->
         <link rel="stylesheet" href="/css/register.css">
@@ -16,7 +16,9 @@
 
             <header class="header">
                 <div class="header-logo">My Portfolio</div>
-                <div class="header-button">ログイン</div>
+                <form action="/logout" method="post" style="display:inline;">
+                    <button type="submit" class="header-button">ログイン</button>
+                </form>
             </header>
 
             <div class="main-content">

--- a/src/main/resources/templates/top.html
+++ b/src/main/resources/templates/top.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="ja">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta name="description" content="ポートフォリオです">
+        <title>TOPページ</title>
+        <link rel="stylesheet" href="/css/common.css">
+        <!--<link rel="stylesheet" href="common.css">-->
+        <link rel="stylesheet" href="/css/top.css">
+        <!--<link rel="stylesheet" href="top.css">-->
+    </head>
+
+    <body>
+        <div class="wrapper">
+
+            <header class="header">
+            <div class="header-logo">My Portfolio</div>
+                <form action="/logout" method="post" style="display:inline;">
+                    <button type="submit" class="header-button">ログアウト</button>
+                </form>
+</header>
+
+
+            <div class="main-content">
+                <form action="/register" method="post" th:object="${userForm}">
+    
+                    <h1 class="main-title">TOP PAGE</h1>
+                    
+                </form>
+            </div>
+            <footer>
+                <div class="footer">portfolio site</div>
+            </footer>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
##  ログイン機能の実装

### チケット
[PRUM_ACADEMY-5199](https://prum.backlog.com/view/PRUM_ACADEMY-5199) 【個人開発6】ログイン機能実装

---

### 概要
ユーザーがメールアドレスとパスワードを入力し、認証後にTOPページへ遷移するログイン機能を実装

---

###  内容
- メールアドレス・パスワードを入力し、DBの内容と一致した場合にログイン可能  
- ログイン成功後はTOP画面にリダイレクト
- 入力情報が一致しない場合、以下のエラーメッセージを `flash` で表示  
- 「新規登録する」ボタンで新規登録画面へ遷移

---

### 変更点

####  コントローラー
- `LoginController` を新規作成
- POST `/login` にてログイン処理を実装

####  ビュー
- `login.html` を作成
- エラーメッセージ表示

####  CSS
- `login.css`を作成

---

###  動作確認

- 正しいメールアドレス・パスワードでログインできることを確認
- 間違った入力時にエラーメッセージが表示されることを確認
- ログイン後、TOP画面に遷移することを確認
- 「新規登録する」ボタンで新規登録画面に遷移することを確認

---

### 備考

Slackにて動画を添付しました。
ご確認よろしくお願いいたします。

