### PR TITLE
Feature/edit profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,12 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+### Custom (OS / app data) ###
+.DS_Store
+
+# ユーザーアップロードは履歴に載せない
+uploads/
+
 ### STS ###
 .apt_generated
 .classpath

--- a/src/main/java/com/spring/springbootapplication/config/WebConfig.java
+++ b/src/main/java/com/spring/springbootapplication/config/WebConfig.java
@@ -1,0 +1,14 @@
+package com.spring.springbootapplication.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations("file:uploads/");
+    }
+}

--- a/src/main/java/com/spring/springbootapplication/config/WebSecurityConfig.java
+++ b/src/main/java/com/spring/springbootapplication/config/WebSecurityConfig.java
@@ -12,6 +12,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
+import com.spring.springbootapplication.service.MyUserDetailsService;
+
 import jakarta.servlet.DispatcherType;
 
 @Configuration
@@ -23,25 +25,35 @@ public class WebSecurityConfig {
     }
 
     // DaoAuthenticationProvider をBean化（使うUDSを明示）
+    //@Bean
+    //public DaoAuthenticationProvider daoAuthProvider(
+    //        @Qualifier("customUserDetailsService") UserDetailsService uds,
+    //        PasswordEncoder encoder) {
+    //    DaoAuthenticationProvider p = new DaoAuthenticationProvider();
+    //    p.setUserDetailsService(uds);
+    //    p.setPasswordEncoder(encoder);
+    //    return p;
+    //}
+
     @Bean
     public DaoAuthenticationProvider daoAuthProvider(
-            @Qualifier("customUserDetailsService") UserDetailsService uds,
-            PasswordEncoder encoder) {
-        DaoAuthenticationProvider p = new DaoAuthenticationProvider();
-        p.setUserDetailsService(uds);
-        p.setPasswordEncoder(encoder);
-        return p;
+        MyUserDetailsService uds,   // ★ 型で特定
+        PasswordEncoder encoder) {
+    var p = new DaoAuthenticationProvider();
+    p.setUserDetailsService(uds);
+    p.setPasswordEncoder(encoder);
+    return p;
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, DaoAuthenticationProvider dao) throws Exception {http
-        .authenticationProvider(dao)
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, DaoAuthenticationProvider dao) throws Exception {
+        http.authenticationProvider(dao)
 
             // 認証の設定: 記載したURLパターンを許可
             .authorizeHttpRequests(auth -> auth
             .dispatcherTypeMatchers(DispatcherType.ERROR, DispatcherType.FORWARD).permitAll()
-            .requestMatchers("/css/**","/js/**","/images/**","/error", "/error/**","/debug/**").permitAll() // ★ CHANGED
-            .requestMatchers("/login", "/register").permitAll()            // ★ CHANGED
+            .requestMatchers("/css/**","/js/**","/images/**","/uploads/**","/error","/error/**","/debug/**").permitAll()
+            .requestMatchers("/login", "/register").permitAll()
             .anyRequest().authenticated()  // それ以外は認証が必要
             )
 

--- a/src/main/java/com/spring/springbootapplication/controller/HomeController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/HomeController.java
@@ -1,19 +1,16 @@
 package com.spring.springbootapplication.controller;
 
-import com.spring.springbootapplication.entity.User;
 import com.spring.springbootapplication.service.UserService;
-
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+
 
 @Controller
 public class HomeController {
 
     private final UserService userService;
-
     public HomeController(UserService userService) {
         this.userService = userService;
     }
@@ -21,29 +18,15 @@ public class HomeController {
     @GetMapping("/home")
     public String home(Authentication auth, Model model) {
         // 認証チェック
-        if (auth == null || !auth.isAuthenticated()
-                || "anonymousUser".equals(String.valueOf(auth.getPrincipal()))) {
+        if (auth == null || !auth.isAuthenticated())
+            return "redirect:/login";
+
+        var user = userService.findUserByEmail(auth.getName()).orElse(null);
+        if (user == null) {
             return "redirect:/login";
         }
 
-        // ★ここで毎回、email を取り出す（メソッド外に出さない）
-        String email;
-        Object principal = auth.getPrincipal();
-        if (principal instanceof org.springframework.security.core.userdetails.User u) {
-            email = u.getUsername();
-        } else if (principal instanceof UserDetails ud) {
-            email = ud.getUsername();
-        } else {
-            email = auth.getName();
-        }
-
-        // DBからユーザー取得（存在しない時のNPE回避）
-        User loginUser = userService.findByEmail(email).orElse(null);
-
-        model.addAttribute("userName", loginUser != null ? loginUser.getName() : email);
-        model.addAttribute("bio", "自己紹介がまだ登録されていません。");
-        model.addAttribute("image", "");
-
-        return "home";
-    }
+        model.addAttribute("user", user); // ← 最新のユーザーをそのまま渡す
+        return "home";    // templates/home.html
+        }                
 }

--- a/src/main/java/com/spring/springbootapplication/controller/ProfileEditController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/ProfileEditController.java
@@ -68,7 +68,7 @@ public class ProfileEditController {
         String v = introduction == null ? "" : introduction.trim();
         if (v.length() < 50 || v.length() > 200) {
             // フィールド専用のエラーを載せる（キー名は何でもOK）
-            ra.addFlashAttribute("introError", "50文字以上、200文字以下で入力してください");
+            ra.addFlashAttribute("introError", "自己紹介は50文字以上、200文字以下で入力してください");
             ra.addFlashAttribute("form", Map.of("introduction", v));
             return "redirect:/profile/edit";
         }

--- a/src/main/java/com/spring/springbootapplication/controller/ProfileEditController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/ProfileEditController.java
@@ -1,0 +1,23 @@
+package com.spring.springbootapplication.controller;
+
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+public class ProfileEditController {
+    @Controller
+public class LoginController {
+
+    //  編集画面表示
+    @GetMapping("/edit")
+    public String showEditForm(Authentication auth, Model model) {
+        if (auth != null && auth.isAuthenticated() && !(auth instanceof AnonymousAuthenticationToken)) {
+            return "redirect:/home";
+        }
+        model.addAttribute("isLoginPage", true);
+        return "home";
+    }
+}
+}

--- a/src/main/java/com/spring/springbootapplication/controller/ProfileEditController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/ProfileEditController.java
@@ -1,23 +1,106 @@
 package com.spring.springbootapplication.controller;
 
+import org.springframework.web.multipart.MultipartFile;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Map;
+import java.util.UUID;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import com.spring.springbootapplication.service.UserService;
+
+import org.springframework.web.bind.annotation.PostMapping;
+
+
+@Controller
+@RequestMapping("/profile")
 public class ProfileEditController {
-    @Controller
-public class LoginController {
+
+    private final UserService userService;
+
+    public ProfileEditController(UserService userService){
+        this.userService = userService;
+    }
 
     //  編集画面表示
     @GetMapping("/edit")
     public String showEditForm(Authentication auth, Model model) {
-        if (auth != null && auth.isAuthenticated() && !(auth instanceof AnonymousAuthenticationToken)) {
-            return "redirect:/home";
+        if (auth == null || !auth.isAuthenticated() || auth instanceof AnonymousAuthenticationToken) {
+            return "redirect:/login";
         }
-        model.addAttribute("isLoginPage", true);
-        return "home";
+        var user = userService.findUserByEmail(auth.getName()).orElse(null);
+        if (user == null) return "redirect:/login";
+
+        model.addAttribute("user", user);
+        return "profile-edit";
+    } 
+
+    @PostMapping("/edit")
+    public String updateProfile(
+        Authentication auth, 
+        @RequestParam("introduction") String introduction,
+        @RequestParam(value = "image", required = false) MultipartFile image,
+        RedirectAttributes ra
+    ) {
+        if (auth == null || !auth.isAuthenticated() || auth instanceof AnonymousAuthenticationToken) {
+            return "redirect:/login";
+        }
+        
+        var userOpt = userService.findUserByEmail(auth.getName());
+        if (userOpt.isEmpty()) {
+            ra.addFlashAttribute("error","ユーザーが見つかりません");
+            return "redirect:/profile/edit"; 
+        }
+
+        var user = userOpt.get();
+
+        // バリデーション
+        String v = introduction == null ? "" : introduction.trim();
+        if (v.length() < 50 || v.length() > 200) {
+            // フィールド専用のエラーを載せる（キー名は何でもOK）
+            ra.addFlashAttribute("introError", "50文字以上、200文字以下で入力してください");
+            ra.addFlashAttribute("form", Map.of("introduction", v));
+            return "redirect:/profile/edit";
+        }
+
+        // 自己紹介を反映
+        user.setIntroduction(v);
+
+        // 画像アップロード
+        if (image != null && !image.isEmpty()) {
+            try (var in = image.getInputStream()) {
+                Path dir = Paths.get("uploads");
+                Files.createDirectories(dir);
+                String filename = UUID.randomUUID() + "_" + (image.getOriginalFilename() == null ? "image" : image.getOriginalFilename());
+                Path dest = dir.resolve(filename);
+                Files.copy(in, dest, StandardCopyOption.REPLACE_EXISTING);
+                user.setAvatarPath("/uploads/" + filename);
+            } catch (Exception e) {
+                System.err.println("画像保存に失敗: " + e.getMessage());
+                ra.addFlashAttribute("error", "画像の保存に失敗しました");
+                ra.addFlashAttribute("form", Map.of("introduction", v));
+                return "redirect:/profile/edit";
+            }
+        }
+
+        // 4) 保存
+        userService.saveProfile(user);
+
+        // 成功時：ホームへ戻す（/home を用意している前提）
+        return "redirect:/home";
+
+
+        }
     }
-}
-}
+
+

--- a/src/main/java/com/spring/springbootapplication/controller/RegisterController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/RegisterController.java
@@ -1,37 +1,39 @@
 package com.spring.springbootapplication.controller;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import com.spring.springbootapplication.dto.UserForm;
+import com.spring.springbootapplication.entity.User;
+import com.spring.springbootapplication.service.UserService;
+
+import jakarta.validation.Valid;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.security.web.context.SecurityContextRepository;
 
-import jakarta.servlet.http.HttpSession;
-import jakarta.validation.Valid;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
-import com.spring.springbootapplication.dto.UserForm;
-import com.spring.springbootapplication.entity.User;
-import com.spring.springbootapplication.service.UserService;
 
 @Controller
 public class RegisterController {
 
-    private final UserService    userService;  
-    private final SecurityContextRepository scRepository
-        = new HttpSessionSecurityContextRepository();
+    private final UserService userService;  
+    private final DaoAuthenticationProvider dao;
+    private final SecurityContextRepository scRepository = new HttpSessionSecurityContextRepository();
 
-    @Autowired
-    public RegisterController(UserService userService) { 
+    public RegisterController(UserService userService, DaoAuthenticationProvider daoAuthProvider) {
         this.userService = userService; 
+        this.dao = daoAuthProvider;
     }
 
     // 登録フォーム表示（GET）
@@ -49,7 +51,6 @@ public class RegisterController {
         @Valid @ModelAttribute("userForm") UserForm userForm,
         BindingResult result,
         RedirectAttributes redirectAttributes,
-        HttpSession session,
         HttpServletRequest request, 
         HttpServletResponse response 
     ){
@@ -76,24 +77,20 @@ public class RegisterController {
         User user = new User();
         user.setName(userForm.getName());
         user.setEmail(userForm.getEmail());
-        //user.setPassword(rawPassword);
         user.setPassword(userForm.getPassword()); // rawを渡すがsaveでencodeされる
-        User savedUser = userService.save(user);
-        
-        //    代わりに UserDetails とトークンを自前で作成
-        UserDetails userDetails = org.springframework.security.core.userdetails.User
-            .withUsername(savedUser.getEmail())
-            .password(savedUser.getPassword())
-            .authorities("ROLE_USER")
-            .build();
+        User savedUser = userService.registerUser(user);
 
-        UsernamePasswordAuthenticationToken authToken =
-            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        // ★ ここに “実ログインと同じProviderで認証” を追加
+        Authentication authentication = dao.authenticate(new UsernamePasswordAuthenticationToken(savedUser.getEmail(), rawPassword)
+        );
 
         SecurityContext context = SecurityContextHolder.createEmptyContext();
-        context.setAuthentication(authToken);
+        ((UsernamePasswordAuthenticationToken) authentication)
+            .setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        context.setAuthentication(authentication);
         SecurityContextHolder.setContext(context);
         scRepository.saveContext(context, request, response);
+        request.changeSessionId(); 
 
         // 登録完了後トップ画面へリダイレクト
         return "redirect:/home";

--- a/src/main/java/com/spring/springbootapplication/dto/UserForm.java
+++ b/src/main/java/com/spring/springbootapplication/dto/UserForm.java
@@ -18,10 +18,11 @@ public class UserForm {
     @NotBlank(message = "パスワードは必ず入力してください")
     @Pattern(
     regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$",
-    message = "英数字8文字以上で入力してください"
-)
-
+    message = "英数字8文字以上で入力してください")
     private String password;
+
+    @Size(min = 50, max = 1000, message = "自己紹介は50文字以上1000文字以内で入力してください")
+    private String introduction; // フォーム用
 
 
     // ----- getter・setter -----

--- a/src/main/java/com/spring/springbootapplication/entity/User.java
+++ b/src/main/java/com/spring/springbootapplication/entity/User.java
@@ -37,7 +37,7 @@ public class User {
     private String email; // メールアドレス
 
     @NotBlank(message = "パスワードは必ず入力してください")
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false, length = 255)
     private String password; // パスワード
 
     @CreatedDate
@@ -45,8 +45,15 @@ public class User {
     private LocalDateTime createdAt; // 登録日時
 
     @LastModifiedDate
-    @Column(name = "updated_at", nullable = false, updatable = false)
+    @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt; // 更新日時
+
+    @Column(name = "introduction", columnDefinition = "TEXT")
+    private String introduction; // 自己紹介 // DB用（バリデーションなし）
+
+    @Column(name = "avatar_path", length = 255)
+    private String avatarPath; // プロフィール画像のファイルパス
+
 
 
     // --- getter・setter ---
@@ -92,5 +99,20 @@ public class User {
         this.updatedAt = updatedAt;
     }
 
+    public String getIntroduction() {
+        return introduction;
+    }
+
+    public void setIntroduction(String introduction) {
+        this.introduction = introduction;
+    }
+
+    public String getAvatarPath() {
+        return avatarPath;
+    }
+
+    public void setAvatarPath(String avatarPath) {
+        this.avatarPath = avatarPath;
+    }
 
 }

--- a/src/main/java/com/spring/springbootapplication/service/MyUserDetailsService.java
+++ b/src/main/java/com/spring/springbootapplication/service/MyUserDetailsService.java
@@ -19,10 +19,12 @@ public class MyUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        System.out.println("ログイン試行中: " + email); // デバッグ用ログ
+        String key = (email == null) ? null : email.trim().toLowerCase();
 
-        User user = userRepository.findByEmail(email)
-            .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
+        System.out.println("ログイン試行中: " + key); // デバッグ用ログ
+    
+        User user = userRepository.findByEmail(key)
+            .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + key));
 
         // DBにはBCrypt済みパスワードが保存されていることが前提
         return org.springframework.security.core.userdetails.User

--- a/src/main/java/com/spring/springbootapplication/service/UserService.java
+++ b/src/main/java/com/spring/springbootapplication/service/UserService.java
@@ -2,6 +2,7 @@ package com.spring.springbootapplication.service;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.spring.springbootapplication.entity.User;
 import com.spring.springbootapplication.repository.UserRepository;
@@ -9,12 +10,12 @@ import com.spring.springbootapplication.repository.UserRepository;
 import java.util.Optional;
 
 @Service
+@Transactional
 public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
-    // 正しいコンストラクタ
     public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
@@ -32,17 +33,33 @@ public class UserService {
         return null;
     }
 
-    public User save(User user) {
-        // パスワードをハッシュ化して保存
+    private String normalizeEmail(String email) {
+        return email == null ? null : email.trim().toLowerCase();
+    }
+
+    
+    public boolean existsByEmail(String email) {
+        return userRepository.existsByEmail(normalizeEmail(email));
+        //String key = email == null ? "" : email.trim();
+        //return userRepository.existsByEmail(key);
+    }
+
+    public Optional<User> findUserByEmail(String email) {
+        return userRepository.findByEmail(normalizeEmail(email));
+        //return userRepository.findByEmail(email == null ? null : email.trim());
+    }
+
+    public User registerUser(User user) {
+        user.setEmail(normalizeEmail(user.getEmail()));
+        // パスワードをハッシュ化してから保存
         user.setPassword(passwordEncoder.encode(user.getPassword()));
         return userRepository.save(user);
     }
 
-    public boolean existsByEmail(String email) {
-        return userRepository.existsByEmail(email);
+    @Transactional
+    public void saveProfile(User user) {
+        // パスワードの再エンコードなどは一切しないで保存
+        userRepository.save(user);
     }
 
-    public Optional<User> findByEmail(String email) {
-        return userRepository.findByEmail(email);
-    }
 }

--- a/src/main/resources/static/css/common.css
+++ b/src/main/resources/static/css/common.css
@@ -58,6 +58,7 @@ label {
     border-radius: 4px;
     color: #000000BF;
     background: #FFFFFF;
+    cursor: pointer;
 }
 
 
@@ -152,7 +153,13 @@ label {
     color: #FFFFFF;  
 }
 
+a{
+    text-decoration: none;
+    cursor: pointer
+}
+
 .text-danger {
+    font-size: 12px;
     margin-top: 5px;
     color: red;  
 } 

--- a/src/main/resources/static/css/home.css
+++ b/src/main/resources/static/css/home.css
@@ -13,6 +13,7 @@ p {
 
 .profile-section{
     display: flex;
+    align-items: center;
     gap: 80px;
     width: 960px;
     margin: 0 auto;
@@ -48,10 +49,16 @@ p {
 
 /* プロフィールコンテンツ */
 .profile-title{
-    margin: 52px 0 32px 0;
+    /* margin: 52px 0 32px 0;*/
+    margin: 0 0 32px 0;
     font-size: 36px;
     font-weight: bold;
     color: #000000BF;
+}
+
+.profile-text{
+    overflow-wrap: anywhere;
+    hyphens: auto;
 }
 
 .profile-title::after {
@@ -70,10 +77,11 @@ p {
     text-align: center;
 }
 
-.profile-contents{
+.profile-content{
     width: 520px;
+    /*margin-top: 60px;*/
     text-align: left;
-    margin-top: 60px;
+    min-width: 0; /* ← flex子要素が内容幅で広がるのを抑止 */
 }
 
 
@@ -92,6 +100,11 @@ p {
     background: #1B5678;
 }
 
+.submit-profile-btn:hover {
+    background-color: #144564;
+    cursor: pointer;
+}
+
 
 
 /* 学習チャート */
@@ -99,6 +112,7 @@ p {
     display: flex;
     flex-direction: column;
     align-items: center;
+    margin-bottom: 30px;
 }
 
 .study-title{
@@ -131,4 +145,9 @@ p {
     border-radius: 4px;
     color: #FFFFFF;
     background: #1B5678;
+}
+
+.submit-edit-btn:hover {
+    background-color: #144564;
+    cursor: pointer;
 }

--- a/src/main/resources/static/css/login.css
+++ b/src/main/resources/static/css/login.css
@@ -11,6 +11,11 @@
     background-color: #1B5678;
 }
 
+.header-button {
+  cursor: inherit;
+}
+
+
 /* 送信ボタン */
 .submit-btn{
     display: flex;

--- a/src/main/resources/static/css/profile-edit.css
+++ b/src/main/resources/static/css/profile-edit.css
@@ -1,1 +1,59 @@
 @import url('/css/common.css');
+
+.bio-textarea{
+    border-top: none;
+    border-right: none;
+    border-left: none;
+    text-align: left; 
+    color: #000000DE;
+}
+
+.file-wrapper{
+    display: flex;
+    flex-direction: column;
+    margin-top: 48px;
+}
+
+.file-input{
+    position:absolute;
+    width:1px;
+    height:1px;
+    margin:-1px;
+    padding:0;
+    border:0;
+    clip:rect(0 0 0 0);
+    overflow:hidden;
+}
+
+.file-btn-wrapper{
+    display: flex;
+    align-items:center;
+}
+
+.file-btn{
+    display:inline-flex;
+    align-items:center;
+    justify-content:center; 
+    margin-top: 4px;
+    width: 202px;
+    height:32px;
+    border-radius: 4px;
+    font-size: 14px;
+    color: #000000BF;
+    background-color: #0000001A;
+    cursor: pointer;
+}
+
+.file-btn:hover{ 
+    background:#eaeaea; 
+}
+
+.file-name { 
+    margin-left: 8px; 
+    font-size: 0.8rem;
+    color: #555; 
+}
+
+.submit-btn{
+    width: 322px;
+}

--- a/src/main/resources/static/js/profile-edit.js
+++ b/src/main/resources/static/js/profile-edit.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const input = document.getElementById('image');
+    const out   = document.getElementById('file-name');
+    if (!input || !out) return;
+
+    input.addEventListener('change', function () {
+        const name = (this.files && this.files.length) ? this.files[0].name : '未選択';
+        out.textContent = name.replace(/^.*[\\\/]/, '');
+    });
+});

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -14,29 +14,28 @@
     <body>
         <div class="wrapper">
 
-            <header class="header">
+        <header class="header">
             <div class="header-logo">My Portfolio</div>
-                <!-- ログアウトボタン: POST メソッド -->
                 <form th:action="@{/logout}" method="post" style="display:inline;">
-                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" /> <!-- ★ 追加 -->
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                     <button type="submit" class="header-button">ログアウト</button>
                 </form>
-            </header>
+        </header>
 
             <div class="main-content">
                 <div class="profile-section">
                     <!-- プロフィール写真 -->
                     <div class="profile-photo">
                         <div class="photo-placeholder">
-                            <img th:src="${#strings.isEmpty(image)} ? @{/images/default_profile.png} : @{${image}}" alt="プロフィール画像" class="profile-img">
+                            <img th:src="${#strings.isEmpty(user?.avatarPath)} ? @{/images/default_profile.png} : @{${user.avatarPath}}" alt="プロフィール画像" class="profile-img">
                         </div>
-                        <p class="user-name" th:text="${userName}"></p>
+                        <p class="user-name" th:text="${user?.name}"></p>
                     </div>
 
                     <!-- 自己紹介コンテンツ -->
                     <div class="profile-content">
                         <h1 class="profile-title">自己紹介</h1>
-                        <p class="profile-description" th:text="${bio}"></p>
+                        <p class="profile-text" th:text="${#strings.isEmpty(user?.introduction) ? '自己紹介がまだ未登録です' : user.introduction}"></p>
                         <a href="/profile/edit" class="submit-profile-btn">自己紹介を編集する</a> 
                     </div>
                 </div>
@@ -52,8 +51,8 @@
 
             <footer>
                 <div class="footer">
-                    <span th:if="${userName != null}"><span th:text="${userName}"></span></span>
-                </div>
+                    <span th:if="${user != null}" th:text="${user.name}">ユーザー名</span>
+                </div>  
             </footer>
         </div>
     </body>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -57,4 +57,4 @@
             </footer>
         </div>
     </body>
-</html>
+</html>     

--- a/src/main/resources/templates/profile-edit.html
+++ b/src/main/resources/templates/profile-edit.html
@@ -1,44 +1,67 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+
 <head>
     <meta charset="UTF-8">
-    <title>ログインページ</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="ポートフォリオです">
+    <title>自己紹介編集ページ</title>
     <link rel="stylesheet" href="/css/common.css">
     <link rel="stylesheet" href="/css/profile-edit.css">
 </head>
+
 <body>
     <div class="wrapper">
-        <header class="header">
-            <div class="header-logo">My Portfolio</div>
-        </header>
 
-        <div class="main-content">
-            <form th:action="@{/login}" method="post">
-                <h1 class="main-title">自己紹介を編集する</h1>
-                <div class="form-container">
-                    <div class="form-group">
-                        <label for="bio">自己紹介文</label>
-                        <textarea id="bio" name="bio" rows="5" placeholder="自己紹介を入力してください">
-                        </textarea>
-                        <!-- ログイン失敗メッセージの表示 -->
-                        <div th:if="${param.error}" class="error-message">
-                            50文字以上、200文字以下で入力してください
-                        </div>
+    <header class="header">
+        <div class="header-logo">My Portfolio</div>
+            <form th:action="@{/logout}" method="post" style="display:inline;">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                <button type="submit" class="header-button">ログアウト</button>
+            </form>
+    </header>
+
+    <div class="main-content">
+        <form th:action="@{/profile/edit}" method="post" enctype="multipart/form-data">
+            <!-- CSRF -->
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+            <h1 class="main-title">自己紹介を編集する</h1>
+
+            <div class="form-container">
+                <div class="form-group">
+                    <label for="introduction">自己紹介文</label>
+                    <!-- ログイン失敗メッセージの表示 -->
+                    <!-- エラー時は flash(form.introduction)、通常は DB の user.introduction -->
+                    <textarea id="introduction" name="introduction" class="bio-textarea" rows="5" 
+                                th:text="${form?.introduction} ?: ${user?.introduction}"></textarea>
+                    <div class="text-danger" th:if="${introError}" th:text="${introError}"></div>
+                    
+                    <div class="file-wrapper">
                         <!-- 画像アップロード -->
                         <label for="image">アバター画像</label>
-                        <input type="file" name="image" id="image" accept="image/*">
-                        <button type="submit">画像ファイルを添付する</button>
-                        <div class="button-wrapper">
-                            <button type="submit" class="submit-btn">自己紹介を確定する</button>
+                        <input type="file" name="image" class="file-input sr-only" id="image" accept="image/*">
+                        <!-- これが見た目のボタンになる -->
+                        <div class="file-btn-wrapper">
+                        <label for="image" class="file-btn">画像ファイルを添付する</label>
+                        <span id="file-name" class="file-name" aria-live="polite"></span>
                         </div>
                     </div>
                 </div>
-            </form>
-        </div>
 
-        <footer>
-            <div class="footer">portfolio site</div>
-        </footer>
-    </div> 
+                <div class="button-wrapper">
+                    <button type="submit" class="submit-btn">自己紹介を確定する</button>
+                </div>
+            </div>
+        </form>
+    </div>
+
+    <footer>
+        <div class="footer">
+        <span th:if="${user != null}" th:text="${user.name}">ユーザー名</span>
+        </div>  
+    </footer>
+
+    </div>
+    <script defer src="/js/profile-edit.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/profile-edit.html
+++ b/src/main/resources/templates/profile-edit.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>ログインページ</title>
+    <link rel="stylesheet" href="/css/common.css">
+    <link rel="stylesheet" href="/css/profile-edit.css">
+</head>
+<body>
+    <div class="wrapper">
+        <header class="header">
+            <div class="header-logo">My Portfolio</div>
+        </header>
+
+        <div class="main-content">
+            <form th:action="@{/login}" method="post">
+                <h1 class="main-title">自己紹介を編集する</h1>
+                <div class="form-container">
+                    <div class="form-group">
+                        <label for="bio">自己紹介文</label>
+                        <textarea id="bio" name="bio" rows="5" placeholder="自己紹介を入力してください">
+                        </textarea>
+                        <!-- ログイン失敗メッセージの表示 -->
+                        <div th:if="${param.error}" class="error-message">
+                            50文字以上、200文字以下で入力してください
+                        </div>
+                        <!-- 画像アップロード -->
+                        <label for="image">アバター画像</label>
+                        <input type="file" name="image" id="image" accept="image/*">
+                        <button type="submit">画像ファイルを添付する</button>
+                        <div class="button-wrapper">
+                            <button type="submit" class="submit-btn">自己紹介を確定する</button>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+
+        <footer>
+            <div class="footer">portfolio site</div>
+        </footer>
+    </div> 
+</body>
+</html>

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -13,16 +13,14 @@
 
     <body>
         <div class="wrapper">
-
             <header class="header">
                 <div class="header-logo">My Portfolio</div>
-                <form action="/logout" method="post" style="display:inline;">
-                    <button type="submit" class="header-button">ログイン</button>
-                </form>
+                <a href="/login" class="header-button">ログイン</a>
             </header>
 
             <div class="main-content">
-                <form action="/register" method="post" th:object="${userForm}">
+                <form th:action="@{/register}" method="post" th:object="${userForm}">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
     
                     <h1 class="main-title">新規登録</h1>
                     <div class="form-container">


### PR DESCRIPTION
##  自己紹介編集機能実装

### チケット
- [PRUM_ACADEMY-5202](https://prum.backlog.com/view/PRUM_ACADEMY-5202) 【個人開発9】自己紹介編集機能実装
---

### 概要
- 自己紹介編集ページの実装をする
---

###  内容
- 自己紹介のテキスト、画像を登録（編集）できる
- バリデーション
-自己紹介
-空ではない
-50文字以上200文字以下
- バリデーションメッセージは自己紹介入力フォームの下に赤字で表示する
-メッセージ
-「自己紹介は50文字以上200文字以下で入力してください」
- 画像ファイルを添付したらファイル名が表示されること
- 「自己紹介を確定する」ボタンを押下で、DBに正しく保存されること
- 登録後はTOP画面に遷移すること
---

### 変更点

####  コントローラー
- `ProfileEditController` を更新
- ログインユーザーのプロフィールが表示
- 「自己紹介を確定する」ボタンでHOMEへ遷移

####  ビュー
- `profile-edit.html` を更新

####  CSS
- `profile-edit.css`を更新
---

####  JS
- `profile-edit.js`を追加
---

###  動作確認

- ログインユーザーのプロフィールが更新されることを確認
- 入力情報が一致しない場合、エラーメッセージを flash で表示
---

### 備考

Slackにて動画を添付しました。
ご確認よろしくお願いいたします。


