### PR TITLE
項目一覧ページ実装

### DIFF
--- a/src/main/java/com/spring/springbootapplication/controller/LearningDataController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/LearningDataController.java
@@ -1,0 +1,61 @@
+package com.spring.springbootapplication.controller;
+
+import com.spring.springbootapplication.service.LearningDataService;
+import com.spring.springbootapplication.service.UserService;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.YearMonth;
+import java.util.List;
+
+@Controller
+public class LearningDataController {
+
+    private final LearningDataService learningDataService;
+    private final UserService userService;
+
+    public LearningDataController(LearningDataService learningDataService, UserService userService) {
+        this.learningDataService = learningDataService;
+        this.userService = userService;
+    }
+
+    @GetMapping("/skills")
+    public String showSkills(@RequestParam(value = "month", required = false) String month,
+                             Authentication auth,
+                             Model model) {
+        // （必要なら）未ログインを弾く
+        if (auth == null || !auth.isAuthenticated()) {
+            return "redirect:/login";
+        }
+
+        // 1) まず selectedMonth を決定（yyyy-MM）
+        String selectedMonth = (month == null || month.isBlank())
+                ? YearMonth.now().toString()
+                : month;
+
+        // 2) プルダウンの候補（月, ラベル）
+        List<LearningDataService.MonthOption> months = learningDataService.pastThreeMonths();
+
+        // 3) 表示ラベルをここで決める（見つからなければフォールバック）
+        String selectedMonthLabel = months.stream()
+                .filter(m -> m.value().equals(selectedMonth))
+                .map(LearningDataService.MonthOption::label)
+                .findFirst()
+                .orElseGet(() -> months.isEmpty() ? "今月" : months.get(0).label());
+
+        // 4) Viewに渡す
+        model.addAttribute("months", months);
+        model.addAttribute("selectedMonth", selectedMonth);
+        model.addAttribute("selectedMonthLabel", selectedMonthLabel);
+
+        // 画面の他のモデルは必要に応じて
+        model.addAttribute("backendSkills", List.of());
+        model.addAttribute("frontendSkills", List.of());
+        model.addAttribute("infraSkills", List.of());
+
+        return "skills";
+    }
+}

--- a/src/main/java/com/spring/springbootapplication/entity/LearningData.java
+++ b/src/main/java/com/spring/springbootapplication/entity/LearningData.java
@@ -3,6 +3,7 @@ package com.spring.springbootapplication.entity;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -23,7 +24,7 @@ import jakarta.validation.constraints.Size;
 
 
 @Entity
-@Table(name = "larning_data")
+@Table(name = "learning_data")
 @EntityListeners(AuditingEntityListener.class)
 public class LearningData {
 
@@ -48,13 +49,14 @@ public class LearningData {
     private LocalDate studyMonth; // 学習実施月
 
     @Column(name = "study_time", nullable = false)
-    private LocalDate studyTime; // 学習時間
+    private Integer studyTime; // 学習時間
 
+    @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt; // 登録日時
 
     @LastModifiedDate
-    @Column(name = "updated_at", nullable = false, updatable = false)
+    @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt; // 更新日時
 
     // --- getter・setter ---
@@ -86,10 +88,10 @@ public class LearningData {
         this.name = name;
     }
 
-    public LocalDate getStudyTime() {
+    public Integer getStudyTime() {
         return studyTime;
     }
-    public void setStudyTime(LocalDate studyTime) {
+    public void setStudyTime(Integer studyTime) {
         this.studyTime = studyTime;
     }
 

--- a/src/main/java/com/spring/springbootapplication/repository/LearningDataRepository.java
+++ b/src/main/java/com/spring/springbootapplication/repository/LearningDataRepository.java
@@ -1,0 +1,41 @@
+package com.spring.springbootapplication.repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.spring.springbootapplication.entity.LearningData;
+import org.springframework.data.domain.Sort; 
+
+public interface LearningDataRepository extends JpaRepository<LearningData, Integer> {
+
+     // 学習データの重複チェック 同一ユーザー、月、スキル名が既に存在するか確認
+    Optional<LearningData> findByUser_IdAndStudyMonthAndName(
+        Long userId,
+        LocalDate studyMonth,
+        String name
+    );
+    
+     // 指定されたカテゴリ名と月の学習データを取得
+    List<LearningData> findByUser_IdAndCategory_NameAndStudyMonth(
+        Long userId,
+        String categoryName,
+        LocalDate studyMonth,
+        Sort Sort
+    );
+    
+
+    // 学習時間の更新
+    Optional<LearningData> findByIdAndUser_Id(Integer Id,Long userId);
+
+    // 削除処理
+    void deleteByIdAndUser_Id(Long id, Long userId);
+
+    // カテゴリごとの各月の合計学習時間を取得
+    List<LearningData> findByUser_IdAndStudyMonthBetween(
+        Long userId,
+        LocalDate startDate,
+        LocalDate endDate
+    );
+}

--- a/src/main/java/com/spring/springbootapplication/service/LearningDataService.java
+++ b/src/main/java/com/spring/springbootapplication/service/LearningDataService.java
@@ -1,0 +1,29 @@
+package com.spring.springbootapplication.service;
+
+import org.springframework.stereotype.Service;
+
+import java.time.YearMonth;
+import java.util.List;
+
+@Service
+public class LearningDataService {
+
+    // プルダウン用：「yyyy-MM」「M月」のペア
+    public record MonthOption(String value, String label) {}
+
+    /// LearningDataService
+    public List<MonthOption> pastThreeMonths() {
+        YearMonth now = YearMonth.now();
+        return java.util.stream.IntStream.range(0, 3) // 0,1,2
+                .mapToObj(i -> {
+                    YearMonth ym = now.minusMonths(i); // 今月, 先月, 先々月
+                    String value = ym.toString();                // "2025-08"
+                    String label = ym.getMonthValue() + "月";     // "8月"
+                    return new MonthOption(value, label);
+                })
+                .toList();
+    }
+
+
+    // ここから下に、あとで一覧/追加/更新/削除などのメソッドを足していけばOK
+}

--- a/src/main/resources/static/css/skills.css
+++ b/src/main/resources/static/css/skills.css
@@ -1,1 +1,314 @@
 @import url('/css/common.css');
+
+/* ========== ヘッダー/レイアウト ========== */
+.skills-header {
+  width: 960px;
+  margin: 40px 0 87px 0;
+}
+
+.skills-container {
+  width: 960px;
+  margin: 0 auto;
+}
+
+.category-box {
+  width: 960px;
+  height: 436px;
+  border-radius: 8px;
+  border: 1px solid #00000080;
+  padding: 40px;
+  margin-bottom: 40px;
+  box-sizing: border-box;
+  display: flex;           /* 内側を縦並び */
+  flex-direction: column;
+  overflow: hidden;        /* はみ出しカット */
+}
+
+.category-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 30px;
+}
+
+h2 { 
+    margin: 0; 
+}
+
+.category-title {
+  font-size: 24px;
+  font-weight: 700;
+  flex-grow: 1;
+  position: relative;
+}
+
+
+.category-title::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -10px;
+  width: 240px;
+  height: 2px;
+  background-color: #00000080;
+}
+
+.skill-edit-btn {
+  box-sizing: border-box;
+  width: 178px;
+  height: 48px;
+  font-size: 14px;
+  margin-left: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 4px;
+  border: none;
+  color: #FFFFFF;
+  background-color: #1B5678;
+}
+
+/* 見出し（項目名 / 学習時間）を細く */
+.skills-list thead th{
+  font-weight: 300;  /* もっと細く → 200 / 普通に → normal(400) */
+}
+
+/* ========== 月プルダウン（カスタム） ========== */
+
+.select-wrap { 
+  position: relative; 
+  display: inline-block; 
+  margin-bottom: 40px;   /* 下方向の全体余白はここで管理 */
+}
+.month-dropdown-btn{ 
+  margin: 0;             /* ここに margin-bottom を持たせない */
+}
+
+.select-wrap { position: relative; display: inline-block; }
+
+.month-menu{
+  position: absolute;
+  left: 0;
+  top: 100%;        /* ボタンの直下 */
+  margin-top: 16px; /* ← ここで距離を16pxに */
+}
+
+.month-dropdown-btn{
+  min-width: 94px;
+  height: 44px;
+  box-sizing: border-box;
+  padding: 8px 16px;
+  font-size: 24px;
+  font-weight: bold;
+  border: 1px solid #DDDDDD;
+  border-radius: 8px;
+  background: #fff;
+  color: #000;
+  display: inline-flex;
+  align-items: center;
+}
+
+.month-dropdown-btn .caret{
+  font-size: 16px;
+  margin-left: auto;
+}
+
+.month-dropdown-btn:hover{ background: #DDDDDD; }
+
+
+.select-wrap { position: relative; display: inline-block; }
+
+
+.month-menu{
+  box-sizing: border-box;
+  min-width: 94px;
+  margin: 0;
+  padding: 6px 0;
+  list-style: none;
+  background: #fff;
+  border: 1px solid #DDD;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0,0,0,.15);
+  z-index: 50;
+  position: absolute;
+  left: 0;
+  top: 100%;        /* ボタンの直下 */
+  margin-top: 16px; /* ← ここで距離を16pxに */
+  
+}
+
+.month-menu li{
+  padding: 10px 16px;
+  font-size: 20px;
+  line-height: 1.2;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.month-menu li:hover,
+.month-menu li:focus{ background: #F2F6FA; outline: none; }
+.month-menu li.is-selected{ background: #E6EEF6; font-weight: 700; }
+
+/* ========== スクロールテーブル（skills用に限定） ========== */
+.skills-list {
+  flex: 1 1 auto;   /* 残り高さを占有 */
+  min-height: 0;    /* これ超重要：flex内での溢れ防止 */
+  width: 880px;
+  height: auto;
+  margin: 0;
+  overflow-y: auto;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,.1);
+}
+
+/* 行ボーダー方式で安定させる（小数px回避） */
+.skills-list table {
+  width: 100%;
+  border-collapse: separate !important;
+  border-spacing: 0 !important;
+}
+
+/* セルの線は消す（行に線を引く） */
+.skills-list th,
+.skills-list td {
+  border-bottom: 1px solid #E0E0E0 !important;
+  box-sizing: border-box;
+  padding: 0 8px;
+  font-size: 14px;
+}
+
+/* 高さ固定（見た目） */
+.skills-list thead th { height: 57px; }
+.skills-list tbody td { height: 72px; }
+
+/* ヘッダー固定＋下線 */
+.skills-list thead {
+  position: sticky;
+  top: 0;
+  background: #fff;
+  z-index: 2;
+}
+.skills-list thead th {
+  border-bottom: 1px solid #E0E0E0 !important;
+}
+
+/* 各行に下線（最後は不要なら下で消せる） */
+.skills-list tbody tr {
+  border-bottom: 1px solid #E0E0E0 !important;
+}
+/* .skills-list tbody tr:last-child { border-bottom: none !important; } */
+
+/* 列幅とアライメント */
+.skills-list th:nth-of-type(1),
+.skills-list td:nth-of-type(1) {
+  width: 240px;
+  text-align: left;
+  padding-left: 50px;
+}
+.skills-list th:nth-of-type(2),
+.skills-list td:nth-of-type(2) {
+  width: 240px;
+  text-align: left;
+  padding-left: 16px;
+}
+.skills-list td:nth-of-type(3) {
+  text-align: left;
+  padding-left: 26px;
+  padding-right: 40px;
+  width: auto; /* ボタン列は伸縮 */
+}
+
+/* ========== 分数入力（160×40）＋ カスタム▲▼ ========== */
+.number-stepper {
+  position: relative;
+  width: 160px;
+  height: 40px;
+}
+
+.learning-hours-input {
+    width: 160px;
+    height: 40px;
+    box-sizing: border-box;          /* 外寸を160×40に固定 */
+    padding: 8px 30px 8px 12px;      /* 右側は▲▼スペース */
+    font-size: 14px;
+    border: 1px solid #0000003B;
+    border-radius: 4px;
+}
+
+/* ネイティブのスピンは消す（見た目を統一） */
+input.minutes-input[type="number"] {
+    -moz-appearance: textfield;
+}
+input.minutes-input[type="number"]::-webkit-inner-spin-button,
+input.minutes-input[type="number"]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+
+}
+
+/* 右側に縦並びの▲▼ */
+.number-stepper .step {
+    position: absolute;
+    right: 2px;
+    width: 22px;
+    height: 20px;
+    line-height: 12px;
+    text-align: center;
+    font-size: 10px;
+    color: #00000080;
+    background: transparent;
+    border: none;
+    border-radius: 0;
+    cursor: pointer;
+    user-select: none;
+    padding: 0;
+}
+.number-stepper .step.up   { top: 4px; }
+.number-stepper .step.down { bottom: 4px; }
+.number-stepper .step:hover { background: rgba(0,0,0,0.06); }
+.number-stepper .step:focus { outline: none; }
+
+/* ========== ボタン（右列） ========== */
+.input-button-wrapper {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 88px;
+}
+
+/* 保存 */
+button.small-btn {
+  width: 158px !important;
+  height: 32px !important;
+  font-size: 14px !important;
+  line-height: 32px;
+  padding: 0;
+  border: 1px solid #1B5678;
+  color: #1B5678;
+  background: #FFFFFF;
+  border-radius: 4px;
+}
+button.small-btn:hover {
+  background: #1B5678;
+  color: #FFFFFF;
+  cursor: pointer;
+}
+
+/* 削除 */
+button.delete-btn {
+  width: 88px !important;
+  height: 32px !important;
+  font-size: 14px !important;
+  line-height: 32px;
+  background: #EE6969;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+}
+button.delete-btn:hover {
+  background: #CC4C4C;
+  cursor: pointer;
+}
+
+/* 念のため固定幅 */
+button.small-btn,
+button.delete-btn { flex: 0 0 auto; }

--- a/src/main/resources/static/css/skills.css
+++ b/src/main/resources/static/css/skills.css
@@ -2,33 +2,33 @@
 
 /* ========== ヘッダー/レイアウト ========== */
 .skills-header {
-  width: 960px;
-  margin: 40px 0 87px 0;
+    width: 960px;
+    margin: 40px 0 87px 0;
 }
 
 .skills-container {
-  width: 960px;
-  margin: 0 auto;
+    width: 960px;
+    margin: 0 auto;
 }
 
 .category-box {
-  width: 960px;
-  height: 436px;
-  border-radius: 8px;
-  border: 1px solid #00000080;
-  padding: 40px;
-  margin-bottom: 40px;
-  box-sizing: border-box;
-  display: flex;           /* 内側を縦並び */
-  flex-direction: column;
-  overflow: hidden;        /* はみ出しカット */
+    width: 960px;
+    height: 436px;
+    border-radius: 8px;
+    border: 1px solid #00000080;
+    padding: 40px;
+    margin-bottom: 40px;
+    box-sizing: border-box;
+    display: flex;           /* 内側を縦並び */
+    flex-direction: column;
+    overflow: hidden;        /* はみ出しカット */
 }
 
 .category-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 30px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 30px;
 }
 
 h2 { 
@@ -36,36 +36,36 @@ h2 {
 }
 
 .category-title {
-  font-size: 24px;
-  font-weight: 700;
-  flex-grow: 1;
-  position: relative;
+    font-size: 24px;
+    font-weight: 700;
+    flex-grow: 1;
+    position: relative;
 }
 
 
 .category-title::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  bottom: -10px;
-  width: 240px;
-  height: 2px;
-  background-color: #00000080;
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -10px;
+    width: 240px;
+    height: 2px;
+    background-color: #00000080;
 }
 
 .skill-edit-btn {
-  box-sizing: border-box;
-  width: 178px;
-  height: 48px;
-  font-size: 14px;
-  margin-left: auto;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  border-radius: 4px;
-  border: none;
-  color: #FFFFFF;
-  background-color: #1B5678;
+    box-sizing: border-box;
+    width: 178px;
+    height: 48px;
+    font-size: 14px;
+    margin-left: auto;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: 4px;
+    border: none;
+    color: #FFFFFF;
+    background-color: #1B5678;
 }
 
 /* 見出し（項目名 / 学習時間）を細く */
@@ -76,8 +76,8 @@ h2 {
 /* ========== 月プルダウン（カスタム） ========== */
 
 .select-wrap { 
-  position: relative; 
-  display: inline-block; 
+    position: relative; 
+    display: inline-block; 
   margin-bottom: 40px;   /* 下方向の全体余白はここで管理 */
 }
 .month-dropdown-btn{ 
@@ -87,30 +87,30 @@ h2 {
 .select-wrap { position: relative; display: inline-block; }
 
 .month-menu{
-  position: absolute;
-  left: 0;
+    position: absolute;
+    left: 0;
   top: 100%;        /* ボタンの直下 */
   margin-top: 16px; /* ← ここで距離を16pxに */
 }
 
 .month-dropdown-btn{
-  min-width: 94px;
-  height: 44px;
-  box-sizing: border-box;
-  padding: 8px 16px;
-  font-size: 24px;
-  font-weight: bold;
-  border: 1px solid #DDDDDD;
-  border-radius: 8px;
-  background: #fff;
-  color: #000;
-  display: inline-flex;
-  align-items: center;
+    min-width: 94px;
+    height: 44px;
+    box-sizing: border-box;
+    padding: 8px 16px;
+    font-size: 24px;
+    font-weight: bold;
+    border: 1px solid #DDDDDD;
+    border-radius: 8px;
+    background: #fff;
+    color: #000;
+    display: inline-flex;
+    align-items: center;
 }
 
 .month-dropdown-btn .caret{
-  font-size: 16px;
-  margin-left: auto;
+    font-size: 16px;
+    margin-left: auto;
 }
 
 .month-dropdown-btn:hover{ background: #DDDDDD; }
@@ -120,29 +120,28 @@ h2 {
 
 
 .month-menu{
-  box-sizing: border-box;
-  min-width: 94px;
-  margin: 0;
-  padding: 6px 0;
-  list-style: none;
-  background: #fff;
-  border: 1px solid #DDD;
-  border-radius: 8px;
-  box-shadow: 0 8px 24px rgba(0,0,0,.15);
-  z-index: 50;
-  position: absolute;
-  left: 0;
+    box-sizing: border-box;
+    min-width: 94px;
+    margin: 0;
+    padding: 6px 0;
+    list-style: none;
+    background: #fff;
+    border: 1px solid #DDD;
+    border-radius: 8px;
+    box-shadow: 0 8px 24px rgba(0,0,0,.15);
+    z-index: 50;
+    position: absolute;
+    left: 0;
   top: 100%;        /* ボタンの直下 */
   margin-top: 16px; /* ← ここで距離を16pxに */
-  
 }
 
 .month-menu li{
-  padding: 10px 16px;
-  font-size: 20px;
-  line-height: 1.2;
-  cursor: pointer;
-  white-space: nowrap;
+    padding: 10px 16px;
+    font-size: 20px;
+    line-height: 1.2;
+    cursor: pointer;
+    white-space: nowrap;
 }
 .month-menu li:hover,
 .month-menu li:focus{ background: #F2F6FA; outline: none; }
@@ -150,30 +149,30 @@ h2 {
 
 /* ========== スクロールテーブル（skills用に限定） ========== */
 .skills-list {
-  flex: 1 1 auto;   /* 残り高さを占有 */
-  min-height: 0;    /* これ超重要：flex内での溢れ防止 */
-  width: 880px;
-  height: auto;
-  margin: 0;
-  overflow-y: auto;
-  border-radius: 4px;
-  box-shadow: 0 2px 4px rgba(0,0,0,.1);
+    flex: 1 1 auto;   /* 残り高さを占有 */
+    min-height: 0;    /* これ超重要：flex内での溢れ防止 */
+    width: 880px;
+    height: auto;
+    margin: 0;
+    overflow-y: auto;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0,0,0,.1);
 }
 
 /* 行ボーダー方式で安定させる（小数px回避） */
 .skills-list table {
-  width: 100%;
-  border-collapse: separate !important;
-  border-spacing: 0 !important;
+    width: 100%;
+    border-collapse: separate !important;
+    border-spacing: 0 !important;
 }
 
 /* セルの線は消す（行に線を引く） */
 .skills-list th,
 .skills-list td {
-  border-bottom: 1px solid #E0E0E0 !important;
-  box-sizing: border-box;
-  padding: 0 8px;
-  font-size: 14px;
+    border-bottom: 1px solid #E0E0E0 !important;
+    box-sizing: border-box;
+    padding: 0 8px;
+    font-size: 14px;
 }
 
 /* 高さ固定（見た目） */
@@ -182,46 +181,46 @@ h2 {
 
 /* ヘッダー固定＋下線 */
 .skills-list thead {
-  position: sticky;
-  top: 0;
-  background: #fff;
-  z-index: 2;
+    position: sticky;
+    top: 0;
+    background: #fff;
+    z-index: 2;
 }
 .skills-list thead th {
-  border-bottom: 1px solid #E0E0E0 !important;
+    border-bottom: 1px solid #E0E0E0 !important;
 }
 
 /* 各行に下線（最後は不要なら下で消せる） */
 .skills-list tbody tr {
-  border-bottom: 1px solid #E0E0E0 !important;
+    border-bottom: 1px solid #E0E0E0 !important;
 }
 /* .skills-list tbody tr:last-child { border-bottom: none !important; } */
 
 /* 列幅とアライメント */
 .skills-list th:nth-of-type(1),
 .skills-list td:nth-of-type(1) {
-  width: 240px;
-  text-align: left;
-  padding-left: 50px;
+    width: 240px;
+    text-align: left;
+    padding-left: 50px;
 }
 .skills-list th:nth-of-type(2),
 .skills-list td:nth-of-type(2) {
-  width: 240px;
-  text-align: left;
-  padding-left: 16px;
+    width: 240px;
+    text-align: left;
+    padding-left: 16px;
 }
 .skills-list td:nth-of-type(3) {
-  text-align: left;
-  padding-left: 26px;
-  padding-right: 40px;
-  width: auto; /* ボタン列は伸縮 */
+    text-align: left;
+    padding-left: 26px;
+    padding-right: 40px;
+    width: auto; /* ボタン列は伸縮 */
 }
 
 /* ========== 分数入力（160×40）＋ カスタム▲▼ ========== */
 .number-stepper {
-  position: relative;
-  width: 160px;
-  height: 40px;
+    position: relative;
+    width: 160px;
+    height: 40px;
 }
 
 .learning-hours-input {
@@ -269,44 +268,44 @@ input.minutes-input[type="number"]::-webkit-outer-spin-button {
 
 /* ========== ボタン（右列） ========== */
 .input-button-wrapper {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 88px;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 88px;
 }
 
 /* 保存 */
 button.small-btn {
-  width: 158px !important;
-  height: 32px !important;
-  font-size: 14px !important;
-  line-height: 32px;
-  padding: 0;
-  border: 1px solid #1B5678;
-  color: #1B5678;
-  background: #FFFFFF;
-  border-radius: 4px;
+    width: 158px !important;
+    height: 32px !important;
+    font-size: 14px !important;
+    line-height: 32px;
+    padding: 0;
+    border: 1px solid #1B5678;
+    color: #1B5678;
+    background: #FFFFFF;
+    border-radius: 4px;
 }
 button.small-btn:hover {
-  background: #1B5678;
-  color: #FFFFFF;
-  cursor: pointer;
+    background: #1B5678;
+    color: #FFFFFF;
+    cursor: pointer;
 }
 
 /* 削除 */
 button.delete-btn {
-  width: 88px !important;
-  height: 32px !important;
-  font-size: 14px !important;
-  line-height: 32px;
-  background: #EE6969;
-  color: #fff;
-  border: none;
-  border-radius: 4px;
+    width: 88px !important;
+    height: 32px !important;
+    font-size: 14px !important;
+    line-height: 32px;
+    background: #EE6969;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
 }
 button.delete-btn:hover {
-  background: #CC4C4C;
-  cursor: pointer;
+    background: #CC4C4C;
+    cursor: pointer;
 }
 
 /* 念のため固定幅 */

--- a/src/main/resources/static/js/skills.js
+++ b/src/main/resources/static/js/skills.js
@@ -1,0 +1,247 @@
+/* =========================
+    skills.js  (フロント用)
+    - 自作プルダウン（過去3ヶ月）
+    - ダミーデータでテーブル描画
+    - 保存/削除の疑似動作
+   ========================= */
+
+'use strict';
+
+// ---------- ユーティリティ ----------
+function ym(back = 0) {
+    const d = new Date();
+    d.setMonth(d.getMonth() - back, 1);
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+  return `${y}-${m}`; // yyyy-MM
+}
+function monthJpLabel(isoYm) {
+  // "2025-08" -> "8月"
+    const m = Number(String(isoYm || '').split('-')[1] || 0);
+    return m ? `${m}月` : '今月';
+}
+function escapeHtml(s){
+    return String(s).replace(/[&<>"']/g, m => ({
+    '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'
+    }[m]));
+}
+
+// ---------- ダミーデータ（month -> category -> rows） ----------
+const DUMMY = {
+    [ym(0)]: {
+    'バックエンド': [
+        { id: 1, name: 'Java',         minutes: 30 },
+        { id: 2, name: 'Ruby',         minutes: 30 },
+        { id: 3, name: 'Spring Boot',  minutes: 30 },
+        { id: 4, name: 'PHP',          minutes: 30 },
+    ],
+    'フロントエンド': [
+        { id: 7, name: 'HTML', minutes: 30 },
+        { id: 8, name: 'CSS',  minutes: 30 },
+    ],
+    'インフラ': [
+        { id: 9,  name: 'AWS',    minutes: 30 },
+        { id: 10, name: 'Heroku', minutes: 30 },
+    ],
+    },
+    [ym(1)]: {
+    'バックエンド':   [{ id: 11, name: 'Java',        minutes: 20 }],
+    'フロントエンド': [{ id: 12, name: 'HTML',        minutes: 20 }],
+    'インフラ':       [{ id: 13, name: 'AWS',         minutes: 20 }],
+    },
+    [ym(2)]: {
+    'バックエンド':   [{ id: 14, name: 'Spring Boot', minutes: 40 }],
+    'フロントエンド': [{ id: 15, name: 'CSS',         minutes: 40 }],
+    'インフラ':       [],
+    },
+};
+
+// ---------- 初期化 ----------
+document.addEventListener('DOMContentLoaded', () => {
+  setupCustomMonthDropdown();     // 自作プルダウンのイベント
+  const initial = getSelectedMonth();  // hidden に入ってる yyyy-MM（無ければ今月）
+
+  // 初期描画（ダミー）
+    renderAll(initial);
+
+  // ここから下は保存/削除のイベント（イベント委任）
+    document.addEventListener('click', onTableButtonClick);
+});
+
+// ---------- 自作プルダウン ----------
+function setupCustomMonthDropdown() {
+    const form  = document.getElementById('monthForm');
+    const btn   = document.getElementById('monthBtn');
+    const menu  = document.getElementById('monthMenu');
+    const label = document.getElementById('monthLabel');
+    const input = document.getElementById('monthInput');
+
+    if (!form || !btn || !menu || !label || !input) return;
+
+    // （保険）menu の li が空なら JS で過去3ヶ月を生成
+    if (menu.children.length === 0) {
+    [0,1,2].forEach(i => {
+        const li = document.createElement('li');
+        const value = ym(i);
+        li.dataset.value = value;
+        li.textContent = monthJpLabel(value);
+        if (i === 0) li.classList.add('is-selected');
+        menu.appendChild(li);
+    });
+    // ラベルも設定（hidden に値があるならそれ優先）
+    label.textContent = monthJpLabel(input.value || ym(0));
+    }
+
+    // 開閉
+    btn.addEventListener('click', (e) => {
+    e.preventDefault();
+    const open = btn.getAttribute('aria-expanded') === 'true';
+    btn.setAttribute('aria-expanded', String(!open));
+    menu.hidden = open;
+    });
+
+    // 項目選択 → hidden へセット → 送信（GET）
+    menu.addEventListener('click', (e) => {
+    const li = e.target.closest('li');
+    if (!li) return;
+
+    input.value = li.dataset.value;
+    label.textContent = li.textContent.trim();
+
+    menu.querySelectorAll('li').forEach(x => x.classList.toggle('is-selected', x === li));
+
+    menu.hidden = true;
+    btn.setAttribute('aria-expanded', 'false');
+
+    // フォーム送信（/skills?month=yyyy-MM）
+    form.submit();
+    });
+
+    // 外側クリックで閉じる
+    document.addEventListener('click', (e) => {
+  // ▲/▼ クリックで1分増減
+  if (e.target.matches('.number-stepper .step')) {
+    const isUp = e.target.classList.contains('up');
+    const input = e.target.closest('.number-stepper').querySelector('.minutes-input');
+    if (!input) return;
+
+    const min = +(input.min || 0);
+    const max = +(input.max || 1440);
+    let v = parseInt(input.value || '0', 10) || 0;
+
+    v += isUp ? 1 : -1;
+    if (v < min) v = min;
+    if (v > max) v = max;
+
+    input.value = v;
+    // 変更イベントを発火（必要なら保存ボタンの活性制御などに使える）
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+
+  // （ここに既存の .save-btn / .delete-btn の処理が続く）
+});
+
+
+    // Escで閉じる
+    document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+        menu.hidden = true;
+        btn.setAttribute('aria-expanded', 'false');
+    }
+    });
+}
+
+function getSelectedMonth(){
+  // サーバが埋めた hidden の month 値（yyyy-MM）
+    const input = document.getElementById('monthInput');
+    return (input && input.value) ? input.value : ym(0);
+}
+
+// ---------- テーブル描画 ----------
+function renderAll(month) {
+    renderCategory('バックエンド', 'tbody-backend', month);
+    renderCategory('フロントエンド', 'tbody-frontend', month);
+    renderCategory('インフラ',     'tbody-infra',     month);
+}
+
+function renderCategory(category, tbodyId, month) {
+  const tbody = document.getElementById(tbodyId);
+  if (!tbody) return;
+
+  tbody.replaceChildren();
+
+  const items = (DUMMY[month]?.[category] || [])
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name, 'ja'));
+
+  if (items.length === 0) {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td colspan="3" style="text-align:center;color:#666;">データがありません</td>`;
+    tbody.appendChild(tr);
+    return;
+  }
+
+  for (const item of items) {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${escapeHtml(item.name)}</td>
+      <td>
+        <div class="number-stepper">
+          <input type="number"
+                 class="learning-hours-input minutes-input"
+                 min="0" max="1440" step="1" inputmode="numeric"
+                 value="${Number(item.minutes) || 0}"
+                 data-id="${item.id}" data-category="${category}">
+          <button type="button" class="step up"   aria-label="1分増やす">▲</button>
+          <button type="button" class="step down" aria-label="1分減らす">▼</button>
+        </div>
+      </td>
+      <td class="input-button-wrapper">
+        <button class="small-btn save-btn"
+                data-id="${item.id}" data-category="${category}">学習時間を保存する</button>
+        <button class="delete-btn"
+                data-id="${item.id}" data-category="${category}">削除する</button>
+      </td>
+    `;
+    tbody.appendChild(tr);
+  }
+}
+
+
+// ---------- 保存/削除（フロントだけの疑似動作） ----------
+function onTableButtonClick(e){
+const month = getSelectedMonth();
+
+    // 保存
+    if (e.target.matches('.save-btn')) {
+    const id       = Number(e.target.dataset.id);
+    const category = e.target.dataset.category;
+    const input    = e.target.closest('tr').querySelector('.minutes-input');
+    const minutes  = Number(input.value);
+
+    const rec = (DUMMY[month]?.[category] || []).find(r => r.id === id);
+    if (rec) rec.minutes = minutes;
+
+    // 本実装では fetch('/skills/update', { method:'POST', body:... }) へ置換
+    alert('学習時間を保存しました。');
+    }
+
+    // 削除
+    if (e.target.matches('.delete-btn')) {
+    const id       = Number(e.target.dataset.id);
+    const category = e.target.dataset.category;
+    if (!confirm('削除してよろしいですか？')) return;
+
+    const list = (DUMMY[month]?.[category] || []);
+    const idx  = list.findIndex(r => r.id === id);
+    if (idx >= 0) list.splice(idx, 1);
+
+    renderCategory(category, tbodyIdFromCategory(category), month);
+    }
+}
+
+function tbodyIdFromCategory(category){
+    return category === 'バックエンド' ? 'tbody-backend'
+        : category === 'フロントエンド' ? 'tbody-frontend'
+        : 'tbody-infra';
+}

--- a/src/main/resources/templates/skills.html
+++ b/src/main/resources/templates/skills.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="ポートフォリオです">
+    <title>項目一覧ページ</title>
+    <link rel="stylesheet" href="/css/common.css">
+    <link rel="stylesheet" href="/css/skills.css">
+</head>
+
+<body>
+    <div class="wrapper">
+
+    <header class="header">
+        <div class="header-logo">My Portfolio</div>
+            <form th:action="@{/logout}" method="post" style="display:inline;">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                <button type="submit" class="header-button">ログアウト</button>
+            </form>
+    </header>
+
+    <div class="main-content">
+        <div class="skills-header">
+
+            <!-- プルダウン -->
+            <form id="monthForm" th:action="@{/skills}" method="get" class="select-wrap">
+                <button type="button"
+                        id="monthBtn"
+                        class="month-dropdown-btn"
+                        aria-haspopup="listbox"
+                        aria-expanded="false">
+                    <span id="monthLabel" th:text="${selectedMonthLabel}">8月</span>
+                    <span class="caret">▼</span>
+                </button>
+
+                <ul id="monthMenu" class="month-menu" role="listbox" hidden>
+                    <li th:each="m : ${months}"
+                        role="option"
+                        th:data-value="${m.value()}"
+                        th:attr="aria-selected=${m.value()==selectedMonth}"
+                        th:classappend="${m.value()==selectedMonth} ? ' is-selected'"
+                        th:text="${m.label()}">
+                    7月
+                    </li>
+                </ul>
+
+                <input type="hidden" name="month" id="monthInput" th:value="${selectedMonth}">
+            </form>
+
+
+
+
+            <div class="skills-container">
+                <!-- バックエンド -->
+                <div class="category-box">
+                    <div class="category-header">
+                        <h2 class="category-title">バックエンド</h2>
+                        <a href="#" class="skill-edit-btn" data-category-id="1" data-category-name="バックエンド" 
+                            onclick="navigateToSkillNew(this)">項目を追加する</a>
+                    </div>
+                    <div class="skills-list">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>項目名</th>
+                                    <th>学習時間</th>
+                                    <th aria-hidden="true"></th>
+                                </tr>
+                            </thead>
+                            <tbody id="tbody-backend"></tbody>
+                        </table>
+                    </div>
+                </div>
+
+                <!-- フロントエンド -->
+                <div class="category-box">
+                    <div class="category-header">
+                        <h2 class="category-title">フロントエンド</h2>
+                        <a href="#" class="skill-edit-btn" data-category-id="1" data-category-name="フロントエンド" 
+                            onclick="navigateToSkillNew(this)">項目を追加する</a>
+                    </div>
+                    <div class="skills-list">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>項目名</th>
+                                    <th>学習時間</th>
+                                    <th aria-hidden="true"></th>
+                                </tr>
+                            </thead>
+                            <tbody id="tbody-frontend"></tbody>
+                        </table>
+                    </div>
+                </div>
+
+                <!-- インフラ -->
+                <div class="category-box">
+                    <div class="category-header">
+                        <h2 class="category-title">インフラ</h2>
+                        <a href="#" class="skill-edit-btn" data-category-id="1" data-category-name="インフラ" 
+                            onclick="navigateToSkillNew(this)">項目を追加する</a>
+                    </div>
+                    <div class="skills-list">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>項目名</th>
+                                    <th>学習時間</th>
+                                    <th aria-hidden="true"></th>
+                                </tr>
+                            </thead>
+                        <tbody id="tbody-infra"></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    </div>
+
+
+    <footer>
+        <div class="footer">portfolio site</div>
+    </footer>
+
+    <script defer src="/js/skills.js?v=20250824_1"></script>
+
+</body>
+</html>


### PR DESCRIPTION
##  項目一覧ページ実装

### チケット
- [PRUM_ACADEMY-5203](https://prum.backlog.com/view/PRUM_ACADEMY-5203) 【個人開発10】項目一覧ページ実装
---

### 概要
- 項目の一覧ページを実装する
---

###  内容
- 一番最初に表示する際は当月のデータが表示される
- 月のデータは当月を含み過去3ヶ月分をプルダウンでそれぞれ選択できる
- プルダウンで選択後、その選択した月のデータが表示される
- 追加、削除、編集は別チケットで実装する
---

### 変更点

####  コントローラー
- `LearningDataController` を更新
- 項目の一覧ページが表示

####  ビュー
- `skills.html` を更新

####  CSS
- `skills.css`を更新
---

####  JS
- `skills.js`を追加
---

###  動作確認

- x項目の一覧ページが表示されることを確認
---

### 備考

Slackにて動画を添付しました。
ご確認よろしくお願いいたします。


