### PR TITLE
項目削除機能実装

### DIFF
--- a/src/main/java/com/spring/springbootapplication/controller/LearningDataController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/LearningDataController.java
@@ -13,6 +13,8 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import java.lang.ProcessBuilder.Redirect;
 import java.time.YearMonth;
 import java.util.List;
+import org.springframework.web.bind.annotation.RequestBody;
+
 
 @Controller
 public class LearningDataController {
@@ -84,4 +86,23 @@ public class LearningDataController {
         // 認証導入前のダミー実装
         return 1L;
     }
+
+    @PostMapping("/skills/delete")
+    public String delete(
+        @RequestParam Integer id,
+        @RequestParam String month,
+        RedirectAttributes ra) {
+
+        Long userId = getLoginUserId();
+       // 表示用メッセージに使うなら削除前に取得
+    var target = learningDataService.deleteByIdForUser(userId, id);
+
+        ra.addFlashAttribute("deleteSuccess", true);
+        ra.addFlashAttribute("deletedCategory", target.getCategory().getName());
+        ra.addFlashAttribute("deletedName", target.getName());
+
+        String normalized = learningDataService.normalizeYm(month);
+        return"redirect:/skills?month=" + normalized;
+        }
+    
 }

--- a/src/main/java/com/spring/springbootapplication/service/LearningDataService.java
+++ b/src/main/java/com/spring/springbootapplication/service/LearningDataService.java
@@ -147,4 +147,15 @@ public LearningData updateMinutes(Long userId, Integer id, int minutes) {
     return repo.save(ld);
 }
 
+    // 学習時間を削除
+public LearningData deleteByIdForUser(Long userId, Integer id) {
+    LearningData ld = repo.findByIdAndUser_Id(id, userId)
+        .orElseThrow(() -> new IllegalArgumentException("データが見つかりません (id=" + id + ")"));
+    ld.getCategory().getName();
+    ld.getName();
+
+    repo.delete(ld);
+
+    return ld; 
+}
 }

--- a/src/main/resources/static/css/skills.css
+++ b/src/main/resources/static/css/skills.css
@@ -453,3 +453,87 @@ dialog#addedModal{
     -webkit-text-fill-color: #111 !important;
     transition: background-color 9999s ease-in-out 0s;
     }
+
+    
+    /* ====== 削除完了モーダル ====== */
+
+/* 画面の暗幕 */
+#deletedModal::backdrop{
+    background: rgba(0,0,0,.6);
+    background-image: linear-gradient(0deg, rgba(0,0,0,.2), rgba(0,0,0,.2));
+    backdrop-filter: blur(1px);
+}
+
+/* 本体カード */
+#deletedModal{
+    width: 640px;
+    height: 240px;
+    max-height: 90vh;
+    padding: 24px 32px;
+
+    border: none;
+    background: #fff;
+    padding: 24px 32px;
+    box-shadow: 0 12px 36px rgba(0,0,0,.25);
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    font-family: Roboto, system-ui, -apple-system, "Segoe UI",
+                "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
+}
+
+/* メッセージ */
+#deletedModal .added-msg{
+    margin: 0;
+    text-align: center;
+    font-weight: 700;
+    font-size: 18px;
+    line-height: 1.6;
+    color: #000000BF;
+    word-break: keep-all;
+}
+
+/* ボタン行 */
+#deletedModal .modal-btn-wrapper{
+    display: flex;
+    justify-content: center;
+    border: none;
+}
+
+/* 「編集ページに戻る」ボタン */
+#deletedModal .modal-btn{
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 192px;
+    height: 48px;
+    margin-top: 40px;
+    border-radius: 4px;
+    text-decoration: none;
+    background: #1B5678;
+    color: #fff;
+    font-size: 14px;
+    cursor: pointer;
+    outline: none !important;
+    box-shadow: none !important;
+    border: none;
+    -webkit-tap-highlight-color: transparent;
+}
+
+/* フォーカス・クリック中も出さない */
+#deletedModal .modal-btn:focus,
+#deletedModal .modal-btn:focus-visible,
+#deletedModal .modal-btn:active {
+    outline: none !important;
+    box-shadow: none !important;
+}
+
+#deletedModal .modal-btn:hover{ background:#144564; }
+
+/* 小さく表示されてしまうUAスタイルへの保険 */
+dialog#deletedModal{
+    max-height: 90vh;
+    overflow: visible;
+}

--- a/src/main/resources/static/js/skills.js
+++ b/src/main/resources/static/js/skills.js
@@ -143,7 +143,9 @@ function monthJpLabel(isoYm) {
 // --- 編集完了モーダルを表示 ---
 (function () {
   function showEditDoneModal() {
-    const dlg = document.getElementById('addedModal') || document.getElementById('editDoneModal');
+    const dlg = document.getElementById('deletedModal')
+            || document.getElementById('addedModal')
+            || document.getElementById('editDoneModal');
     if (!dlg) return;
 
     // 開く
@@ -155,16 +157,14 @@ function monthJpLabel(isoYm) {
 
     // ===== ここから後始末（残像対策） =====
     const forceRepaint = () => {
-      // 同期reflowで::backdropの塗りを確実に消す
       void document.body.offsetHeight;
     };
 
     // 「閉じた」後に強制再描画 → ついでにDOMから取り除くと最も確実
     dlg.addEventListener('close', () => {
-      // まれにclose直後はpaintが残るので、次フレームで処理
       requestAnimationFrame(() => {
         forceRepaint();
-        dlg.remove();  // 同ページで再表示しないならremoveが一番キレイ
+        dlg.remove();  
       });
     });
 
@@ -178,7 +178,6 @@ function monthJpLabel(isoYm) {
 
     // フォームボタン(method="dialog")で閉じる場合の保険
     dlg.querySelector('.modal-btn')?.addEventListener('click', () => {
-      // method="dialog"で自動closeされるけど、二重で呼んでもOK
       dlg.close();
     });
     // ===== 後始末ここまで =====

--- a/src/main/resources/templates/skills.html
+++ b/src/main/resources/templates/skills.html
@@ -97,8 +97,7 @@
                                         </form>
 
                                         <!-- 削除 -->
-                                        <form th:action="@{/skills/delete}" method="post" style="display:inline;"
-                                                onsubmit="return confirm('削除してよろしいですか？');">
+                                        <form th:action="@{/skills/delete}" method="post" style="display:inline;">
                                             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                                             <input type="hidden" name="id"    th:value="${s.id}" />
                                             <input type="hidden" name="month" th:value="${selectedMonth}" />
@@ -166,8 +165,7 @@
                                     </form>
 
                                     <!-- 削除 -->
-                                    <form th:action="@{/skills/delete}" method="post" style="display:inline;"
-                                            onsubmit="return confirm('削除してよろしいですか？');">
+                                    <form th:action="@{/skills/delete}" method="post" style="display:inline;">
                                         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                                         <input type="hidden" name="id"    th:value="${s.id}" />
                                         <input type="hidden" name="month" th:value="${selectedMonth}" />
@@ -235,8 +233,7 @@
                                     </form>
 
                                     <!-- 削除 -->
-                                    <form th:action="@{/skills/delete}" method="post" style="display:inline;"
-                                            onsubmit="return confirm('削除してよろしいですか？');">
+                                    <form th:action="@{/skills/delete}" method="post" style="display:inline;">
                                         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                                         <input type="hidden" name="id"    th:value="${s.id}" />
                                         <input type="hidden" name="month" th:value="${selectedMonth}" />
@@ -268,6 +265,16 @@
     <dialog class="modal-wrapper" id="addedModal" th:if="${editSuccess}">
         <p class="added-msg"
             th:text="${editedName} + 'を保存しました！'">
+        </p>
+        <form method="dialog" class="modal-btn-wrapper">
+            <button class="modal-btn">編集ページに戻る</button>
+        </form>
+    </dialog>
+
+    <!-- 追加：削除完了モーダル（flash が来ているときだけ描画） -->
+    <dialog class="modal-wrapper" id="deletedModal" th:if="${deleteSuccess}">
+        <p class="added-msg"
+            th:text="${deletedName} + 'を削除しました！'">
         </p>
         <form method="dialog" class="modal-btn-wrapper">
             <button class="modal-btn">編集ページに戻る</button>


### PR DESCRIPTION
##  項目削除機能実装

### チケット
- [PRUM_ACADEMY-5206](https://prum.backlog.com/view/PRUM_ACADEMY-5206) 【個人開発13】項目削除機能実装
---

### 概要
- 項目の削除機能を実装する
---

###  内容
- 「削除する」ボタンを押下すると該当の項目が削除される（物理削除）
- 正しく削除できると[削除確認モーダル]が表示される
- モーダルの「編集ページに戻る」を押下すると[項目一覧画面]に遷移すること
---

### 変更点

####  Controller
- `LearningDataController` を更新
- `SkillsController` を更新

####  Service
- `LearningDataService` を更新

####  Repository
- `LearningDataRepository を更新

####  ビュー
- `skills.html` を更新

####  CSS
- `skills.css`を更新
---

####  JS
- `skills.js`を更新
---

###  動作確認
- 「削除する」ボタンを押下すると該当の項目が削除されるができることを確認
---

### 備考

Slackにて動画を添付しました。
ご確認よろしくお願いいたします。


