### PR TITLE
スキルチャート表示実装

### DIFF
--- a/src/main/java/com/spring/springbootapplication/controller/LearningDataController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/LearningDataController.java
@@ -68,7 +68,6 @@ public class LearningDataController {
         ra.addFlashAttribute("editSuccess", true);
         ra.addFlashAttribute("editedCategory", updated.getCategory().getName());
         ra.addFlashAttribute("editedName", updated.getName());
-         feature/skills-chart-guard-port
         ra.addFlashAttribute("editedMinutes", safe); // テンプレ側がどちらでも読めるように
 
         return "redirect:/skills-legacy?month=" + learningDataService.normalizeYm(month);
@@ -130,5 +129,4 @@ public class LearningDataController {
 
         return "redirect:/skills-legacy?month=" + learningDataService.normalizeYm(form.getMonth());
     }
-}
 }

--- a/src/main/java/com/spring/springbootapplication/service/LearningDataService.java
+++ b/src/main/java/com/spring/springbootapplication/service/LearningDataService.java
@@ -148,7 +148,7 @@ public class LearningDataService {
         ld.setStudyTime(safe);
         return repo.save(ld);
     }
-  
+
     // ===== 学習時間を削除（冪等 & 表示用情報を返す）=====
     public static record DeletedInfo(String name, String category) {}
 

--- a/src/main/java/com/spring/springbootapplication/service/LearningDataService.java
+++ b/src/main/java/com/spring/springbootapplication/service/LearningDataService.java
@@ -171,7 +171,7 @@ public class LearningDataService {
         try {
             // 実際の削除。delete(ld) / deleteById のどちらでもOK
             repo.delete(ld);
-        } catch (EmptyResultDataAccessException ex) {
+        } catch (EmptyResultDataAccessException ex) {   
             // 並行で既に他リクエストが削除した等のレース：成功扱いで握る
         }
 


### PR DESCRIPTION
##  項目削除機能実装

### チケット
- [PRUM_ACADEMY-5207](https://prum.backlog.com/view/PRUM_ACADEMY-5207) 【個人開発14】スキルチャート表示実装
---

### 概要
- スキルチャート表示の実装をする
---

###  内容
- ライブラリは自由に利用可
- バックエンド、フロントエンド、インフラで登録した項目の学習時間がチャートとして表示される
- 学習時間は上限なしで全て表示される
- 削除された項目の時間は含まない
---

### 変更点

####  Controller
- `LearningDataController` を更新
- `SkillsController` を更新

####  Service
- `LearningDataService` を更新

####  Repository
- `LearningDataRepository` を更新

####  ビュー
- `skills.html` を更新

####  CSS
- `skills.css`を更新
---

####  JS
- `skills.js`を更新
---

###  動作確認
- バックエンド、フロントエンド、インフラで登録した項目の学習時間がチャートとして表示されることを確認
---

### 備考

Slackにて動画を添付しました。
ご確認よろしくお願いいたします。


